### PR TITLE
Fix unordered segment_files; add MKVMerge as a concat option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # will have compiled files and executables
 debug/
 target/
+logs/
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ sha2 = "0.10"
 hex = "0.4.3"
 futures = "0.3.30"
 tracing-appender = "0.2"
+path_abs = "0.5.1"
 
 [build-dependencies]
 tonic-build = "0.9"

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -8,7 +8,7 @@ use video_encoding::video_encoding_service_server::{
     VideoEncodingService, VideoEncodingServiceServer,
 };
 use video_encoding::{EncodeChunkRequest, EncodeChunkResponse};
-use video_encoding_system::chunk::{verify_ffmpeg, Chunk};
+use video_encoding_system::chunk::{verify_binaries, Chunk};
 
 pub mod video_encoding {
     tonic::include_proto!("video_encoding");
@@ -140,7 +140,7 @@ async fn main() -> Result<()> {
 
     let settings = load_settings(&cli)?;
 
-    verify_ffmpeg()?;
+    verify_binaries(&"ffmpeg".to_string())?;
 
     let config = TempConfig::new(
         Some(settings.processing.temp_dir),

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -122,16 +122,28 @@ pub fn split_video(
 ///
 /// A Result indicating success or a VideoEncodeError if FFmpeg is not found
 #[instrument]
-pub fn verify_ffmpeg() -> Result<(), VideoEncodeError> {
+pub fn verify_binaries(concat: &String) -> Result<(), VideoEncodeError> {
     debug!("Verifying FFmpeg installation");
+    let mut result = Ok(());
     match which::which("ffmpeg") {
         Ok(path) => {
-            info!("FFmpeg found at: {:?}", path);
-            Ok(())
+            info!("FFmpeg found at: {path:?}");
         }
         Err(e) => {
             error!("FFmpeg not found: {}", e);
-            Err(VideoEncodeError::FfmpegNotFound)
+            result = Err(VideoEncodeError::FfmpegNotFound);
         }
     }
+    if concat == "mkvmerge" {
+        match which::which("mkvmerge") {
+            Ok(path) => {
+                info!("MKVMerge found at: {path:?}");
+            }
+            Err(e) => {
+                error!("MKVMerge not found: {e}");
+                result = Err(VideoEncodeError::MkvmergeNotFound);
+            }
+        }
+    }
+    result
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,9 @@ pub enum VideoEncodeError {
     #[error("FFmpeg not found")]
     FfmpegNotFound,
 
+    #[error("MKVMerge not found")]
+    MkvmergeNotFound,
+
     #[error("Serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 

--- a/src/ffmpeg/concat.rs
+++ b/src/ffmpeg/concat.rs
@@ -1,8 +1,139 @@
 use crate::error::VideoEncodeError;
-use std::fs;
+use path_abs::{PathAbs, PathInfo};
+use std::fmt::Write as hi;
+use std::fs::File;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use tracing::{debug, error, info, instrument};
+use tracing::{error, info, debug, instrument};
+
+#[derive(Debug)]
+pub enum OutputError {
+    Path(String),
+    Fs(String),
+    MkvMergeFailed(String),
+    Io(std::io::Error),
+}
+
+pub fn mkvmerge(
+    temp_dir: &Path,
+    output: &Path,
+    encoder_extension: &str,
+    num_tasks: usize,
+) -> Result<(), OutputError> {
+    #[cfg(windows)]
+    fn fix_path<P: AsRef<Path>>(p: P) -> String {
+        const UNC_PREFIX: &str = r#"\\?\"#;
+
+        let p = p.as_ref().display().to_string();
+        if let Some(path) = p.strip_prefix(UNC_PREFIX) {
+            if let Some(p2) = path.strip_prefix("UNC") {
+                format!("\\{}", p2)
+            } else {
+                path.to_string()
+            }
+        } else {
+            p
+        }
+    }
+
+    #[cfg(not(windows))]
+    fn fix_path<P: AsRef<Path>>(p: P) -> String {
+        p.as_ref().display().to_string()
+    }
+
+    let mut audio_file = PathBuf::from(&temp_dir);
+    audio_file.push("audio.mkv");
+    let audio_file = PathAbs::new(&audio_file).map_err(|err| OutputError::Path(err.to_string()))?;
+    let audio_file = if audio_file.as_path().exists() {
+        Some(fix_path(audio_file))
+    } else {
+        None
+    };
+
+    let mut encode_dir = PathBuf::from(temp_dir);
+    encode_dir.push("encoded");
+
+    let output = PathAbs::new(output).map_err(|err| OutputError::Path(err.to_string()))?;
+
+    assert!(num_tasks != 0);
+
+    let options_path = PathBuf::from(&temp_dir).join("options.json");
+    let options_json_contents = mkvmerge_options_json(
+        num_tasks,
+        encoder_extension,
+        &fix_path(output.to_str().unwrap()),
+        audio_file.as_deref(),
+    );
+
+    let mut options_json =
+        File::create(options_path).map_err(|err| OutputError::Fs(err.to_string()))?;
+    options_json
+        .write_all(options_json_contents.as_bytes())
+        .map_err(|err| OutputError::Fs(err.to_string()))?;
+
+    let mut cmd = Command::new("mkvmerge");
+    cmd.current_dir(&encode_dir);
+    cmd.arg("@../options.json");
+
+    let out = cmd.output().map_err(|e| OutputError::Io(e))?;
+
+    if !out.status.success() {
+        error!(
+            "mkvmerge concatenation failed with output: {:#?}\ncommand: {:?}",
+            out, cmd
+        );
+        return Err(OutputError::MkvMergeFailed(
+            String::from_utf8_lossy(&out.stderr).into(),
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn mkvmerge_options_json(num: usize, ext: &str, output: &str, audio: Option<&str>) -> String {
+    let mut file_string = String::with_capacity(64 + 12 * num);
+    write!(file_string, "[\"-o\", {output:?}").unwrap();
+    if let Some(audio) = audio {
+        write!(file_string, ", {audio:?}").unwrap();
+    }
+    file_string.push_str(", \"[\"");
+    for i in 0..num {
+        write!(file_string, ", \"encoded_chunk_{i}.{ext}\"").unwrap();
+    }
+    file_string.push_str(",\"]\"]");
+
+    file_string
+}
+
+fn ffmpeg_mux(concat: String, input: String, output: String) -> Result<(), OutputError> {
+    let ffmpeg_args = vec![
+        "-f",
+        "concat",
+        "-safe",
+        "0",
+        "-i",
+        &concat,
+        "-i",
+        &input,
+        "-map",
+        "0:v", // map video from concatenated segments
+        "-map",
+        "1", // map all streams from original input
+        "-c",
+        "copy",
+        &output,
+    ];
+
+    debug!("FFmpeg command: ffmpeg {:?}", ffmpeg_args);
+
+    // Execute FFmpeg command
+    Command::new("ffmpeg")
+        .arg("-hide_banner")
+        .args(&ffmpeg_args)
+        .status().map_err(|e| OutputError::Io(e))?;
+    Ok(())
+}
 
 /// Concatenates video segments and adds back non-video streams.
 #[instrument(skip(segment_paths))]
@@ -12,6 +143,7 @@ pub fn concatenate_videos_and_copy_streams(
     output_file: &Path,
     temp_dir: &PathBuf,
     expected_segments: usize,
+    concat: &String,
 ) -> Result<(), VideoEncodeError> {
     // Verify that all segments exist and match the expected count
     if segment_paths.len() != expected_segments {
@@ -31,48 +163,28 @@ pub fn concatenate_videos_and_copy_streams(
         }
     }
 
-    // Create a temporary file list for FFmpeg
-    // Unfortunately due to current implementation path of the files inside
-    // is relative to the file
-    let temp_file_list = PathBuf::from("file_list.txt");
-    let file_list_content: String = segment_paths
-        .iter()
-        .map(|path| format!("file '{}'\n", path.to_str().unwrap()))
-        .collect();
-    fs::write(&temp_file_list, file_list_content)?;
+    let status = if concat == "ffmpeg" {
+        // Create a temporary file list for FFmpeg
+        // Unfortunately due to current implementation path of the files inside
+        // is relative to the file
+        let temp_file_list = PathBuf::from("file_list.txt");
+        let file_list_content: String = segment_paths
+            .iter()
+            .map(|path| format!("file '{}'\n", path.to_str().unwrap()))
+            .collect();
+        std::fs::write(&temp_file_list, file_list_content)?;
+    
+        let temp_st = temp_file_list.to_string_lossy();
+        let original_input = original_input.to_string_lossy();
+        let output_file = output_file.to_string_lossy();
 
-    let temp_st = temp_file_list.to_string_lossy();
-    let original_input = original_input.to_string_lossy();
-    let output_file = output_file.to_string_lossy();
+        ffmpeg_mux(temp_st.into(), original_input.into(), output_file.into())
+    } else {
+        mkvmerge(&temp_dir, &output_file, "mkv".into(), expected_segments)
+    };
 
-    // Prepare FFmpeg command
-    let ffmpeg_args = vec![
-        "-f",
-        "concat",
-        "-safe",
-        "0",
-        "-i",
-        &temp_st,
-        "-i",
-        &original_input,
-        "-map",
-        "0:v", // map video from concatenated segments
-        "-map",
-        "1", // map all streams from original input
-        "-c",
-        "copy",
-        &output_file,
-    ];
-
-    debug!("FFmpeg command: ffmpeg {:?}", ffmpeg_args);
-
-    // Execute FFmpeg command
-    let status = Command::new("ffmpeg")
-        .arg("-hide_banner")
-        .args(&ffmpeg_args)
-        .status()?;
-
-    if !status.success() {
+    if status.is_err() {
+        eprintln!("{status:?}");
         error!("Failed to concatenate videos and copy streams");
         return Err(VideoEncodeError::Concatenation(
             "Failed to concatenate videos and copy streams".to_string(),
@@ -85,7 +197,7 @@ pub fn concatenate_videos_and_copy_streams(
     );
 
     // Clean up temporary file
-    fs::remove_file(temp_file_list)?;
+    // fs::remove_file(temp_file_list)?;
 
     Ok(())
 }

--- a/src/ffmpeg/concat.rs
+++ b/src/ffmpeg/concat.rs
@@ -1,7 +1,7 @@
 use crate::error::VideoEncodeError;
 use path_abs::{PathAbs, PathInfo};
 use std::fmt::Write as hi;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -163,11 +163,11 @@ pub fn concatenate_videos_and_copy_streams(
         }
     }
 
+    let temp_file_list = PathBuf::from("file_list.txt");
     let status = if concat == "ffmpeg" {
         // Create a temporary file list for FFmpeg
         // Unfortunately due to current implementation path of the files inside
         // is relative to the file
-        let temp_file_list = PathBuf::from("file_list.txt");
         let file_list_content: String = segment_paths
             .iter()
             .map(|path| format!("file '{}'\n", path.to_str().unwrap()))
@@ -197,7 +197,7 @@ pub fn concatenate_videos_and_copy_streams(
     );
 
     // Clean up temporary file
-    // fs::remove_file(temp_file_list)?;
+    fs::remove_file(temp_file_list)?;
 
     Ok(())
 }

--- a/src/ffmpeg/segment.rs
+++ b/src/ffmpeg/segment.rs
@@ -1,3 +1,4 @@
+use crate::error::VideoEncodeError;
 /// This module is responsible for segmenting input file
 /// into multiple independent files which are ready for processing
 /// TODO: separating audio before segmenting
@@ -5,11 +6,9 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-
-use crate::error::VideoEncodeError;
 use tracing::{debug, error, info, instrument};
 
-use crate::chunk::verify_ffmpeg;
+use crate::chunk::verify_binaries;
 
 /// Due to the nature of method -segment_time
 /// Getting expected number of segments is not
@@ -27,7 +26,7 @@ pub fn segment_video(
         input_path, segment_duration, segment_dir
     );
 
-    verify_ffmpeg()?;
+    verify_binaries(&"ffmpeg".to_string())?;
     debug!("FFmpeg verification successful");
 
     std::fs::create_dir_all(segment_dir)?;

--- a/src/ffmpeg/segment.rs
+++ b/src/ffmpeg/segment.rs
@@ -79,7 +79,7 @@ pub fn segment_video(
 
     debug!("Video segmentation completed successfully");
 
-    let segmented_files: Vec<PathBuf> = std::fs::read_dir(segment_dir)?
+    let mut segmented_files: Vec<PathBuf> = std::fs::read_dir(segment_dir)?
         .filter_map(Result::ok)
         .filter(|entry| entry.path().extension().and_then(|s| s.to_str()) == Some("mp4"))
         .map(|entry| {
@@ -87,6 +87,7 @@ pub fn segment_video(
             path
         })
         .collect();
+    segmented_files.sort();
 
     debug!(
         "Segmented files: count={}, files={:?}",


### PR DESCRIPTION
This fixes a bug where segments would be associated with the wrong chunks, by sorting segment_files. This also adds an option to concatenate using MKVMerge, the code of which was copied from Av1an 0.4.5 commit cbb6362.